### PR TITLE
Fix cURL's WRITEFUNCTION undefined behavior leading to segfault

### DIFF
--- a/src/functions/get_tranco.cpp
+++ b/src/functions/get_tranco.cpp
@@ -24,7 +24,7 @@ namespace duckdb
             // Construct the URL for the daily list
             std::string url = "https://tranco-list.eu/daily_list?date=" + std::string (date) + "&subdomains=true";
 
-            LogMessage (LogLevel::INFO, "Get Tranco download code for date: " + std::string (date));
+            LogMessage (LogLevel::LOG_INFO, "Get Tranco download code for date: " + std::string (date));
 
             curl_easy_setopt (curl, CURLOPT_URL, url.c_str ());
             curl_easy_setopt (curl, CURLOPT_WRITEDATA, &readBuffer);
@@ -33,8 +33,8 @@ namespace duckdb
 
             if (res != CURLE_OK)
             {
-                LogMessage (LogLevel::ERROR, std::string (curl_easy_strerror (res)));
-                LogMessage (LogLevel::CRITICAL, "Failed to fetch Tranco download code.");
+                LogMessage (LogLevel::LOG_ERROR, std::string (curl_easy_strerror (res)));
+                LogMessage (LogLevel::LOG_CRITICAL, "Failed to fetch Tranco download code.");
             }
 
             // Extract the download code from the URL
@@ -42,11 +42,11 @@ namespace duckdb
             std::smatch code_match;
             if (std::regex_search (readBuffer, code_match, code_regex) && code_match.size () > 1)
             {
-                LogMessage (LogLevel::INFO, "Tranco download code: " + code_match[1].str ());
+                LogMessage (LogLevel::LOG_INFO, "Tranco download code: " + code_match[1].str ());
                 return code_match[1].str ();
             }
 
-            LogMessage (LogLevel::CRITICAL, "Failed to extract Tranco download code.");
+            LogMessage (LogLevel::LOG_CRITICAL, "Failed to extract Tranco download code.");
         }
 
         // Function to download the Tranco list and create a table
@@ -78,7 +78,7 @@ namespace duckdb
                 // Construct the download URL
                 std::string download_url = "https://tranco-list.eu/download/" + download_code + "/full";
 
-                LogMessage (LogLevel::INFO, "Download Tranco list: " + download_url);
+                LogMessage (LogLevel::LOG_INFO, "Download Tranco list: " + download_url);
 
                 // Download the CSV file to a temporary file
                 CURL *curl = CreateCurlHandler (WriteFileCallback);
@@ -87,7 +87,7 @@ namespace duckdb
                 if (!file)
                 {
                     curl_easy_cleanup (curl);
-                    LogMessage (LogLevel::CRITICAL, "Failed to create temporary file for Tranco list.");
+                    LogMessage (LogLevel::LOG_CRITICAL, "Failed to create temporary file for Tranco list.");
                 }
 
                 curl_easy_setopt (curl, CURLOPT_URL, download_url.c_str ());
@@ -99,18 +99,18 @@ namespace duckdb
                 if (res != CURLE_OK)
                 {
                     remove (temp_file.c_str ()); // Clean up the temporary file
-                    LogMessage (LogLevel::ERROR, std::string (curl_easy_strerror (res)));
-                    LogMessage (LogLevel::CRITICAL, "Failed to download Tranco list. Check logs for details.");
+                    LogMessage (LogLevel::LOG_ERROR, std::string (curl_easy_strerror (res)));
+                    LogMessage (LogLevel::LOG_CRITICAL, "Failed to download Tranco list. Check logs for details.");
                 }
             }
 
             if (!file.good ())
             {
-                LogMessage (LogLevel::CRITICAL, "Tranco list `" + temp_file + "` not found. Download it first using `SELECT update_tranco(true);`");
+                LogMessage (LogLevel::LOG_CRITICAL, "Tranco list `" + temp_file + "` not found. Download it first using `SELECT update_tranco(true);`");
             }
 
             // Parse the CSV data and insert into a table
-            LogMessage (LogLevel::INFO, "Inserting Tranco list into table");
+            LogMessage (LogLevel::LOG_INFO, "Inserting Tranco list into table");
 
             Connection con (db);
             string query = "CREATE OR REPLACE TABLE tranco_list AS"
@@ -133,7 +133,7 @@ namespace duckdb
 
             if (result->HasError ())
             {
-                LogMessage (LogLevel::CRITICAL, result->GetError ());
+                LogMessage (LogLevel::LOG_CRITICAL, result->GetError ());
             }
         }
 
@@ -162,7 +162,7 @@ namespace duckdb
 
             if (table_exists->RowCount () == 0)
             {
-                LogMessage (LogLevel::CRITICAL, "Tranco table not found. Download it first using `SELECT update_tranco(true);`");
+                LogMessage (LogLevel::LOG_CRITICAL, "Tranco table not found. Download it first using `SELECT update_tranco(true);`");
             }
 
             // Extract the input from the arguments
@@ -201,7 +201,7 @@ namespace duckdb
 
             if (table_exists->RowCount () == 0)
             {
-                LogMessage (LogLevel::CRITICAL, "Tranco table not found. Download it first using `SELECT update_tranco(true);`");
+                LogMessage (LogLevel::LOG_CRITICAL, "Tranco table not found. Download it first using `SELECT update_tranco(true);`");
             }
 
             // Extract the input from the arguments

--- a/src/functions/get_tranco.cpp
+++ b/src/functions/get_tranco.cpp
@@ -17,7 +17,7 @@ namespace duckdb
         // Function to get the download code for the Tranco list
         std::string GetTrancoDownloadCode (char *date)
         {
-            CURL *curl = CreateCurlHandler ();
+            CURL *curl = CreateCurlHandler (WriteStringCallback);
             CURLcode res;
             std::string readBuffer;
 
@@ -81,7 +81,7 @@ namespace duckdb
                 LogMessage (LogLevel::INFO, "Download Tranco list: " + download_url);
 
                 // Download the CSV file to a temporary file
-                CURL *curl = CreateCurlHandler ();
+                CURL *curl = CreateCurlHandler (WriteFileCallback);
                 CURLcode res;
                 FILE *file = fopen (temp_file.c_str (), "wb");
                 if (!file)

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -15,24 +15,24 @@ namespace duckdb
             const char *env_level = std::getenv ("LOG_LEVEL");
             if (env_level == nullptr)
             {
-                return LogLevel::INFO; // default level
+                return LogLevel::LOG_INFO; // default level
             }
 
             std::string level_str (env_level);
             if (level_str == "DEBUG")
-                return LogLevel::DEBUG;
+                return LogLevel::LOG_DEBUG;
             if (level_str == "INFO")
-                return LogLevel::INFO;
+                return LogLevel::LOG_INFO;
             if (level_str == "WARNING")
-                return LogLevel::WARNING;
+                return LogLevel::LOG_WARNING;
             if (level_str == "ERROR")
-                return LogLevel::ERROR;
+                return LogLevel::LOG_ERROR;
             if (level_str == "CRITICAL")
-                return LogLevel::CRITICAL;
+                return LogLevel::LOG_CRITICAL;
 
             std::cerr << "Unknown LOG_LEVEL environment variable value: " << level_str
                       << ". Defaulting to INFO." << std::endl;
-            return LogLevel::INFO;
+            return LogLevel::LOG_INFO;
         }
 
         std::string getCurrentTimestamp ()
@@ -57,11 +57,11 @@ namespace duckdb
             const char *level_str = "";
             switch (level)
             {
-            case LogLevel::DEBUG: level_str = "DEBUG"; break;
-            case LogLevel::INFO: level_str = "INFO"; break;
-            case LogLevel::WARNING: level_str = "WARNING"; break;
-            case LogLevel::ERROR: level_str = "ERROR"; break;
-            case LogLevel::CRITICAL: level_str = "CRITICAL"; break;
+            case LogLevel::LOG_DEBUG: level_str = "DEBUG"; break;
+            case LogLevel::LOG_INFO: level_str = "INFO"; break;
+            case LogLevel::LOG_WARNING: level_str = "WARNING"; break;
+            case LogLevel::LOG_ERROR: level_str = "ERROR"; break;
+            case LogLevel::LOG_CRITICAL: level_str = "CRITICAL"; break;
             }
 
             std::ofstream log_file ("netquack.log", std::ios_base::app);
@@ -76,13 +76,13 @@ namespace duckdb
                      << message << std::endl;
 
             // Also output to stderr for error levels
-            if (level >= LogLevel::ERROR)
+            if (level >= LogLevel::LOG_ERROR)
             {
                 std::cerr << "[" << level_str << "] " << message << std::endl;
             }
 
             // Throw exception for critical errors
-            if (level == LogLevel::CRITICAL)
+            if (level == LogLevel::LOG_CRITICAL)
             {
                 throw std::runtime_error (message);
             }

--- a/src/utils/logger.hpp
+++ b/src/utils/logger.hpp
@@ -8,13 +8,14 @@ namespace duckdb
 {
     namespace netquack
     {
+        // Note: `LOG_` prefix is to avoid problems with DEBUG and ERROR macros
         enum class LogLevel
         {
-            DEBUG,
-            INFO,
-            WARNING,
-            ERROR,
-            CRITICAL
+            LOG_DEBUG,
+            LOG_INFO,
+            LOG_WARNING,
+            LOG_ERROR,
+            LOG_CRITICAL
         };
 
         // Function to log messages with a specified log level

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -37,7 +37,7 @@ namespace duckdb
             CURL *curl = curl_easy_init ();
             if (!curl)
             {
-                LogMessage (LogLevel::CRITICAL, "Failed to initialize CURL");
+                LogMessage (LogLevel::LOG_CRITICAL, "Failed to initialize CURL");
             }
 
             const char *ca_info = std::getenv ("CURL_CA_INFO");
@@ -69,14 +69,14 @@ namespace duckdb
             {
                 // Set the custom CA certificate bundle file
                 // https://github.com/hatamiarash7/duckdb-netquack/issues/6
-                LogMessage (LogLevel::DEBUG, "Using custom CA certificate bundle: " + std::string (ca_info));
+                LogMessage (LogLevel::LOG_DEBUG, "Using custom CA certificate bundle: " + std::string (ca_info));
                 curl_easy_setopt (curl, CURLOPT_CAINFO, ca_info);
             }
             const char *ca_path = std::getenv ("CURL_CA_PATH");
             if (ca_path)
             {
                 // Set the custom CA certificate directory
-                LogMessage (LogLevel::DEBUG, "Using custom CA certificate directory: " + std::string (ca_path));
+                LogMessage (LogLevel::LOG_DEBUG, "Using custom CA certificate directory: " + std::string (ca_path));
                 curl_easy_setopt (curl, CURLOPT_CAPATH, ca_path);
             }
 
@@ -108,8 +108,8 @@ namespace duckdb
 
             if (res != CURLE_OK)
             {
-                LogMessage (LogLevel::ERROR, std::string (curl_easy_strerror (res)));
-                LogMessage (LogLevel::CRITICAL, "Failed to download public suffix list. Check logs for details.");
+                LogMessage (LogLevel::LOG_ERROR, std::string (curl_easy_strerror (res)));
+                LogMessage (LogLevel::LOG_CRITICAL, "Failed to download public suffix list. Check logs for details.");
             }
 
             return readBuffer;
@@ -125,14 +125,14 @@ namespace duckdb
 
             if (table_exists->RowCount () == 0 || table_data->RowCount () <= 1 || force)
             {
-                LogMessage (LogLevel::INFO, "Loading public suffix list...");
+                LogMessage (LogLevel::LOG_INFO, "Loading public suffix list...");
                 // Download the list
                 auto list_data = DownloadPublicSuffixList ();
 
                 // Validate the downloaded data
                 if (list_data.empty ())
                 {
-                    LogMessage (LogLevel::CRITICAL, "Failed to download public suffix list: empty data received");
+                    LogMessage (LogLevel::LOG_CRITICAL, "Failed to download public suffix list: empty data received");
                 }
 
                 // Count non-comment/non-empty lines for validation
@@ -150,11 +150,11 @@ namespace duckdb
 
                 if (valid_line_count <= 1)
                 {
-                    LogMessage (LogLevel::ERROR, validation_line);
-                    LogMessage (LogLevel::CRITICAL, "Downloaded public suffix list contains no valid entries. Try again or run `SELECT update_suffixes();`.");
+                    LogMessage (LogLevel::LOG_ERROR, validation_line);
+                    LogMessage (LogLevel::LOG_CRITICAL, "Downloaded public suffix list contains no valid entries. Try again or run `SELECT update_suffixes();`.");
                 }
 
-                LogMessage (LogLevel::INFO, "Downloaded public suffix list with " + std::to_string (valid_line_count) + " valid entries");
+                LogMessage (LogLevel::LOG_INFO, "Downloaded public suffix list with " + std::to_string (valid_line_count) + " valid entries");
 
                 // Parse the list and insert into a table
                 std::istringstream stream (list_data);

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -10,11 +10,14 @@ namespace duckdb
 {
     namespace netquack
     {
-        // Function to get a CURL handler
-        CURL *CreateCurlHandler ();
+        // Function to get a CURL handler with custom write callback
+        CURL *CreateCurlHandler (curl_write_callback write_callback);
 
-        // Function to download a file from a URL
-        size_t WriteCallback (void *contents, size_t size, size_t nmemb, void *userp);
+        // Function to write data to a string (for HTTP responses)
+        size_t WriteStringCallback (char *contents, size_t size, size_t nmemb, void *userp);
+
+        // Function to write data to a file (for file downloads)
+        size_t WriteFileCallback (char *contents, size_t size, size_t nmemb, void *userp);
 
         // Function to download the public suffix list
         std::string DownloadPublicSuffixList ();

--- a/test/sql/update_tranco.test_slow
+++ b/test/sql/update_tranco.test_slow
@@ -1,0 +1,10 @@
+# name: test/sql/update_tranco.test_slow
+# description: test netquack extension update_tranco function
+# group: [netquack]
+
+require netquack
+
+query I
+SELECT update_tranco(true);
+----
+Tranco list updated


### PR DESCRIPTION
This ensures we rely on the right `CURLOPT_WRITEFUNCTION` depending on whether we write to a string or to a file.

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: 0x000000010180bc04 libclang_rt.asan_osx_dynamic.dylib`__sanitizer_internal_memmove + 132
    frame #1: 0x000000010183da70 libclang_rt.asan_osx_dynamic.dylib`wrap_memcpy + 148
    frame #2: 0x0000000193c34208 libc++.1.dylib`std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::append(char const*, unsigned long) + 144
    frame #3: 0x0000000122c24cac libduckdb.1.4.dylib`duckdb::netquack::WriteCallback(contents=0x0000629009808229, size=1, nmemb=1360, userp=0x0000000201ca69d8) at utils.cpp:87:37
    frame #4: 0x00000001ad832298 libcurl.4.dylib`cw_out_ptr_flush + 184
    frame #5: 0x00000001ad831f5c libcurl.4.dylib`cw_out_do_write + 168
    frame #6: 0x00000001ad831d64 libcurl.4.dylib`cw_out_write + 84
    frame #7: 0x00000001ad809ed8 libcurl.4.dylib`cw_download_write + 524
    frame #8: 0x00000001ad8195e4 libcurl.4.dylib`Curl_xfer_write_resp + 68
    frame #9: 0x00000001ad7f1004 libcurl.4.dylib`on_data_chunk_recv + 108
    frame #10: 0x00000001a215b800 libapple_nghttp2.dylib`nghttp2_session_mem_recv2 + 8316
    frame #11: 0x00000001ad7f1dc4 libcurl.4.dylib`h2_process_pending_input + 88
    frame #12: 0x00000001ad7f012c libcurl.4.dylib`h2_progress_ingress + 360
    frame #13: 0x00000001ad7eeffc libcurl.4.dylib`cf_h2_recv + 192
    frame #14: 0x00000001ad7cc3b0 libcurl.4.dylib`Curl_conn_recv + 48
    frame #15: 0x00000001ad8185c0 libcurl.4.dylib`Curl_readwrite + 448
    frame #16: 0x00000001ad8016bc libcurl.4.dylib`multi_runsingle + 1884
    frame #17: 0x00000001ad800eb4 libcurl.4.dylib`curl_multi_perform + 204
    frame #18: 0x00000001ad7db1b0 libcurl.4.dylib`curl_easy_perform + 272
    frame #19: 0x0000000122c0b338 libduckdb.1.4.dylib`duckdb::netquack::LoadTrancoList(db=0x000061b000004d98, force=true) at get_tranco.cpp:95:23
```