### PR TITLE
Add `extract_path_segments` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Table of Contents
     - [Base64 Encode / Decode](#base64-encode--decode)
     - [Validate URL](#validate-url)
     - [Validate Domain](#validate-domain)
+    - [Extract Path Segments](#extract-path-segments)
     - [Get Extension Version](#get-extension-version)
   - [Build Requirements](#build-requirements)
   - [Debugging](#debugging)
@@ -793,6 +794,44 @@ D SELECT is_valid_domain('localhost') AS valid;
 └─────────┘
 ```
 
+### Extract Path Segments
+
+The `extract_path_segments` table function splits a URL path into individual segment rows. Each row contains a 1-based `segment_index` and the `segment` string. Returns 0 rows for `NULL`, empty, or root-only paths.
+
+```sql
+D SELECT * FROM extract_path_segments('https://example.com/path/to/page?q=1');
+┌───────────────┬─────────┐
+│ segment_index │ segment │
+│     int32     │ varchar │
+├───────────────┼─────────┤
+│             1 │ path    │
+│             2 │ to      │
+│             3 │ page    │
+└───────────────┴─────────┘
+```
+
+Use with `LATERAL` to expand segments per row in a table:
+
+```sql
+D SELECT u.url,
+      s.segment_index,
+      s.segment
+  FROM urls u,
+      LATERAL extract_path_segments(u.url) s
+  ORDER BY u.url,
+      s.segment_index;
+┌───────────────────────────┬───────────────┬─────────┐
+│            url            │ segment_index │ segment │
+│          varchar          │     int32     │ varchar │
+├───────────────────────────┼───────────────┼─────────┤
+│ https://example.com/a/b/c │             1 │ a       │
+│ https://example.com/a/b/c │             2 │ b       │
+│ https://example.com/a/b/c │             3 │ c       │
+│ https://test.org/x/y      │             1 │ x       │
+│ https://test.org/x/y      │             2 │ y       │
+└───────────────────────────┴───────────────┴─────────┘
+```
+
 ### Get Extension Version
 
 You can use the `netquack_version` function to get the extension version.
@@ -839,7 +878,6 @@ Also, there will be stdout errors for background tasks like CURL.
 - [ ] Implement `ip_in_range` function - Check if an IP falls within a given CIDR block
 - [ ] Support internationalized domain names (IDNs)
 - [ ] Implement `punycode_encode` / `punycode_decode` functions - Convert internationalized domain names to/from ASCII-compatible encoding
-- [ ] Implement `extract_path_segments` table function - Split a URL path into individual segment rows
 
 ## Contributing 🤝
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,6 +26,7 @@
 * [Base64 Encode / Decode](functions/base64-functions.md)
 * [Validate URL](functions/is-valid-url.md)
 * [Validate Domain](functions/is-valid-domain.md)
+* [Extract Path Segments](functions/extract-path-segments.md)
 * [Tranco](functions/tranco/README.md)
   * [Get Tranco Rank](functions/tranco/get-tranco-rank.md)
   * [Download / Update Tranco](functions/tranco/download-update-tranco.md)

--- a/docs/functions/extract-path-segments.md
+++ b/docs/functions/extract-path-segments.md
@@ -1,0 +1,68 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# Extract Path Segments
+
+The `extract_path_segments` table function splits a URL path into individual segment rows. Each row contains a 1-based `segment_index` and the `segment` string. This is useful for analyzing URL structures, filtering by path depth, or joining path components.
+
+```sql
+D SELECT * FROM extract_path_segments('https://example.com/path/to/page?q=1');
+┌───────────────┬─────────┐
+│ segment_index │ segment │
+│     int32     │ varchar │
+├───────────────┼─────────┤
+│             1 │ path    │
+│             2 │ to      │
+│             3 │ page    │
+└───────────────┴─────────┘
+```
+
+```sql
+D SELECT * FROM extract_path_segments('https://api.example.com/v3/users/42/repos');
+┌───────────────┬─────────┐
+│ segment_index │ segment │
+│     int32     │ varchar │
+├───────────────┼─────────┤
+│             1 │ v3      │
+│             2 │ users   │
+│             3 │ 42      │
+│             4 │ repos   │
+└───────────────┴─────────┘
+```
+
+## LATERAL Join
+
+Use with `LATERAL` to expand path segments per row in a table:
+
+```sql
+D SELECT u.url,
+      s.segment_index,
+      s.segment
+  FROM urls u,
+      LATERAL extract_path_segments(u.url) s
+  ORDER BY u.url,
+      s.segment_index;
+┌───────────────────────────┬───────────────┬─────────┐
+│            url            │ segment_index │ segment │
+│          varchar          │     int32     │ varchar │
+├───────────────────────────┼───────────────┼─────────┤
+│ https://example.com/a/b/c │             1 │ a       │
+│ https://example.com/a/b/c │             2 │ b       │
+│ https://example.com/a/b/c │             3 │ c       │
+│ https://test.org/x/y      │             1 │ x       │
+│ https://test.org/x/y      │             2 │ y       │
+└───────────────────────────┴───────────────┴─────────┘
+```
+
+Returns 0 rows for URLs with no path, root path (`/`), empty strings, and `NULL` input.

--- a/src/functions/extract_path_segments.cpp
+++ b/src/functions/extract_path_segments.cpp
@@ -1,0 +1,155 @@
+// Copyright 2026 Arash Hatami
+
+#include "extract_path_segments.hpp"
+
+#include "../utils/url_helpers.hpp"
+
+#include <string>
+#include <vector>
+
+namespace duckdb {
+namespace netquack {
+
+// ---------------------------------------------------------------------------
+// Pure logic: extract path from URL, then split into non-empty segments
+// ---------------------------------------------------------------------------
+std::vector<std::string> ExtractPathSegments(const std::string &input) {
+	std::vector<std::string> segments;
+
+	if (input.empty()) {
+		return segments;
+	}
+
+	const char *data = input.data();
+	size_t size = input.size();
+	const char *pos = data;
+	const char *end = pos + size;
+
+	// Locate the path start (same logic as ExtractPath)
+	pos = find_first_symbols<'/'>(pos, end);
+	if (end == pos) {
+		return segments;
+	}
+
+	bool has_subsequent_slash = pos + 1 < end && pos[1] == '/';
+	if (has_subsequent_slash) {
+		pos = find_first_symbols<'/'>(pos + 2, end);
+		if (end == pos) {
+			return segments;
+		}
+	}
+
+	// Path ends at '?' or '#'
+	const char *path_end = find_first_symbols<'?', '#'>(pos, end);
+
+	// Skip leading '/'
+	if (pos < path_end && *pos == '/') {
+		++pos;
+	}
+
+	// Split on '/'
+	const char *seg_start = pos;
+	for (const char *cur = pos; cur <= path_end; ++cur) {
+		if (cur == path_end || *cur == '/') {
+			if (cur > seg_start) {
+				segments.emplace_back(seg_start, cur - seg_start);
+			}
+			seg_start = cur + 1;
+		}
+	}
+
+	return segments;
+}
+
+// ---------------------------------------------------------------------------
+// Table function callbacks
+// ---------------------------------------------------------------------------
+struct ExtractPathSegmentsData : public TableFunctionData {};
+
+struct ExtractPathSegmentsLocalState : public LocalTableFunctionState {
+	std::vector<std::string> segments;
+	idx_t current_idx = 0;
+	bool done = false;
+};
+
+unique_ptr<FunctionData> ExtractPathSegmentsFunc::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types, vector<string> &names) {
+	// Output columns: segment_index (1-based) and segment
+	return_types.emplace_back(LogicalType(LogicalTypeId::INTEGER));
+	names.emplace_back("segment_index");
+
+	return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+	names.emplace_back("segment");
+
+	return make_uniq<ExtractPathSegmentsData>();
+}
+
+unique_ptr<LocalTableFunctionState> ExtractPathSegmentsFunc::InitLocal(ExecutionContext &context,
+                                                                       TableFunctionInitInput &input,
+                                                                       GlobalTableFunctionState *global_state_p) {
+	return make_uniq<ExtractPathSegmentsLocalState>();
+}
+
+OperatorResultType ExtractPathSegmentsFunc::Function(ExecutionContext &context, TableFunctionInput &data_p,
+                                                     DataChunk &input, DataChunk &output) {
+	auto &local_state = data_p.local_state->Cast<ExtractPathSegmentsLocalState>();
+
+	// Already finished outputting for this input row — request next input
+	if (local_state.done) {
+		local_state.done = false;
+		local_state.segments.clear();
+		local_state.current_idx = 0;
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	// Continue outputting remaining segments from a previous HAVE_MORE_OUTPUT
+	if (!local_state.segments.empty() && local_state.current_idx < local_state.segments.size()) {
+		idx_t count = 0;
+		while (local_state.current_idx < local_state.segments.size() && count < STANDARD_VECTOR_SIZE) {
+			output.data[0].SetValue(count, Value::INTEGER(static_cast<int32_t>(local_state.current_idx + 1)));
+			output.data[1].SetValue(count, Value(local_state.segments[local_state.current_idx]));
+			++local_state.current_idx;
+			++count;
+		}
+		output.SetCardinality(count);
+
+		if (local_state.current_idx >= local_state.segments.size()) {
+			local_state.done = true;
+		}
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	}
+
+	// Parse the URL from the input chunk
+	auto url_value = input.data[0].GetValue(0);
+	if (url_value.IsNull()) {
+		output.SetCardinality(0);
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	auto url = url_value.GetValue<string>();
+	local_state.segments = ExtractPathSegments(url);
+	local_state.current_idx = 0;
+
+	if (local_state.segments.empty()) {
+		output.SetCardinality(0);
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	// Output as many segments as we can
+	idx_t count = 0;
+	while (local_state.current_idx < local_state.segments.size() && count < STANDARD_VECTOR_SIZE) {
+		output.data[0].SetValue(count, Value::INTEGER(static_cast<int32_t>(local_state.current_idx + 1)));
+		output.data[1].SetValue(count, Value(local_state.segments[local_state.current_idx]));
+		++local_state.current_idx;
+		++count;
+	}
+	output.SetCardinality(count);
+
+	if (local_state.current_idx >= local_state.segments.size()) {
+		local_state.done = true;
+	}
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
+} // namespace netquack
+} // namespace duckdb

--- a/src/functions/extract_path_segments.hpp
+++ b/src/functions/extract_path_segments.hpp
@@ -1,0 +1,24 @@
+// Copyright 2026 Arash Hatami
+
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+namespace netquack {
+
+// Table function to split a URL path into individual segment rows
+struct ExtractPathSegmentsFunc {
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<string> &names);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state_p);
+	static OperatorResultType Function(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+	                                   DataChunk &output);
+};
+
+// Pure logic: extract path segments from a URL
+std::vector<std::string> ExtractPathSegments(const std::string &input);
+
+} // namespace netquack
+} // namespace duckdb

--- a/src/netquack_extension.cpp
+++ b/src/netquack_extension.cpp
@@ -13,6 +13,7 @@
 #include "functions/extract_fragment.hpp"
 #include "functions/extract_host.hpp"
 #include "functions/extract_path.hpp"
+#include "functions/extract_path_segments.hpp"
 #include "functions/extract_port.hpp"
 #include "functions/extract_query.hpp"
 #include "functions/extract_schema.hpp"
@@ -137,6 +138,12 @@ static void LoadInternal(ExtensionLoader &loader) {
 	auto is_valid_domain_function =
 	    ScalarFunction("is_valid_domain", {LogicalType::VARCHAR}, LogicalType::BOOLEAN, IsValidDomainFunction);
 	loader.RegisterFunction(is_valid_domain_function);
+
+	auto extract_path_segments_function =
+	    TableFunction("extract_path_segments", {LogicalType::VARCHAR}, nullptr, netquack::ExtractPathSegmentsFunc::Bind,
+	                  nullptr, netquack::ExtractPathSegmentsFunc::InitLocal);
+	extract_path_segments_function.in_out_function = netquack::ExtractPathSegmentsFunc::Function;
+	loader.RegisterFunction(extract_path_segments_function);
 
 	auto version_function =
 	    TableFunction("netquack_version", {}, netquack::VersionFunc::Scan, netquack::VersionFunc::Bind,

--- a/test/sql/extract_path_segments.test
+++ b/test/sql/extract_path_segments.test
@@ -1,0 +1,221 @@
+# name: test/sql/extract_path_segments.test
+# description: test netquack extract_path_segments table function
+# group: [sql]
+
+require netquack
+
+# === Basic URL with Path ===
+
+query II
+SELECT * FROM extract_path_segments('https://example.com/path/to/page');
+----
+1	path
+2	to
+3	page
+
+# Single segment
+query II
+SELECT * FROM extract_path_segments('https://example.com/page');
+----
+1	page
+
+# Many segments
+query II
+SELECT * FROM extract_path_segments('https://example.com/a/b/c/d/e');
+----
+1	a
+2	b
+3	c
+4	d
+5	e
+
+# === URL with Query and Fragment ===
+
+# Path stops at query string
+query II
+SELECT * FROM extract_path_segments('https://example.com/path/to/page?q=1&r=2');
+----
+1	path
+2	to
+3	page
+
+# Path stops at fragment
+query II
+SELECT * FROM extract_path_segments('https://example.com/path/to/file.html#section');
+----
+1	path
+2	to
+3	file.html
+
+# Path stops at query before fragment
+query II
+SELECT * FROM extract_path_segments('https://example.com/a/b?x=1#frag');
+----
+1	a
+2	b
+
+# === Bare Domain with Path ===
+
+query II
+SELECT * FROM extract_path_segments('example.com/a/b/c');
+----
+1	a
+2	b
+3	c
+
+# === Standalone Path ===
+
+query II
+SELECT segment_index, segment FROM extract_path_segments('/api/v2/users/123/posts');
+----
+1	api
+2	v2
+3	users
+4	123
+5	posts
+
+# === File Extension in Path ===
+
+query II
+SELECT * FROM extract_path_segments('https://cdn.example.com/assets/images/logo.png');
+----
+1	assets
+2	images
+3	logo.png
+
+# === Empty / No Path Cases ===
+
+# Root path only
+query II
+SELECT * FROM extract_path_segments('https://example.com/');
+----
+
+# No path at all
+query II
+SELECT * FROM extract_path_segments('https://example.com');
+----
+
+# Empty string
+query II
+SELECT * FROM extract_path_segments('');
+----
+
+# NULL returns 0 rows
+query II
+SELECT * FROM extract_path_segments(NULL);
+----
+
+# === Trailing Slash ===
+
+query II
+SELECT * FROM extract_path_segments('https://example.com/path/to/');
+----
+1	path
+2	to
+
+# === Double Slashes in Path ===
+
+query II
+SELECT * FROM extract_path_segments('https://example.com/path//double');
+----
+1	path
+2	double
+
+# === URL with Port ===
+
+query II
+SELECT * FROM extract_path_segments('https://example.com:8080/api/data');
+----
+1	api
+2	data
+
+# === URL with Userinfo ===
+
+query II
+SELECT * FROM extract_path_segments('https://user:pass@example.com/dashboard/settings');
+----
+1	dashboard
+2	settings
+
+# === Protocol-relative URL ===
+
+query II
+SELECT * FROM extract_path_segments('//example.com/assets/main.js');
+----
+1	assets
+2	main.js
+
+# === Encoded Characters in Path ===
+
+query II
+SELECT * FROM extract_path_segments('https://example.com/path%20with%20spaces/file');
+----
+1	path%20with%20spaces
+2	file
+
+# === Table Usage ===
+
+statement ok
+CREATE OR REPLACE TABLE test_urls (url VARCHAR);
+
+statement ok
+INSERT INTO test_urls VALUES
+    ('https://example.com/a/b/c'),
+    ('https://test.org/x/y'),
+    ('https://empty.com/'),
+    (NULL);
+
+query III
+SELECT u.url, s.segment_index, s.segment
+FROM test_urls u, LATERAL extract_path_segments(u.url) s
+ORDER BY u.url, s.segment_index;
+----
+https://example.com/a/b/c	1	a
+https://example.com/a/b/c	2	b
+https://example.com/a/b/c	3	c
+https://test.org/x/y	1	x
+https://test.org/x/y	2	y
+
+statement ok
+DROP TABLE test_urls;
+
+# === Count Segments per URL ===
+
+statement ok
+CREATE OR REPLACE TABLE urls_depth (url VARCHAR);
+
+statement ok
+INSERT INTO urls_depth VALUES
+    ('https://example.com/a/b/c'),
+    ('https://test.org/x'),
+    ('https://deep.com/1/2/3/4/5');
+
+query II
+SELECT u.url, COUNT(*) AS segment_count
+FROM urls_depth u, LATERAL extract_path_segments(u.url) s
+GROUP BY u.url
+ORDER BY segment_count;
+----
+https://test.org/x	1
+https://example.com/a/b/c	3
+https://deep.com/1/2/3/4/5	5
+
+statement ok
+DROP TABLE urls_depth;
+
+# === API-style Paths ===
+
+query II
+SELECT * FROM extract_path_segments('https://api.example.com/v3/users/42/repos');
+----
+1	v3
+2	users
+3	42
+4	repos
+
+# === Single Segment with Query ===
+
+query II
+SELECT * FROM extract_path_segments('https://example.com/search?q=duckdb');
+----
+1	search


### PR DESCRIPTION
[skip ci]Split a URL path into individual segment rows with a 1-based index — supports LATERAL joins for per-row expansion.

### Changes

| File | Change |
|------|--------|
| `src/functions/extract_path_segments.hpp` | New header — `ExtractPathSegmentsFunc` struct (Bind/InitLocal/Function) and `ExtractPathSegments()` pure logic |
| `src/functions/extract_path_segments.cpp` | Implementation — extracts path, strips query/fragment, splits on `/`, skips empty segments, returns `segment_index` (INTEGER) + `segment` (VARCHAR) |
| `src/netquack_extension.cpp` | Register `extract_path_segments` as a table function with `in_out_function` |
| `test/sql/extract_path_segments.test` | Comprehensive tests — basic paths, query/fragment stripping, bare domains, standalone paths, file extensions, empty/root/NULL, trailing slash, double slashes, port, userinfo, protocol-relative URLs, encoded chars, LATERAL join, COUNT aggregation, API-style paths |
| `docs/functions/extract-path-segments.md` | GitBook documentation with usage examples and LATERAL join |
| `docs/SUMMARY.md` | Navigation entry |
| `README.md` | ToC entry, usage section, roadmap item marked complete |
| `functions.csv` | New function entry |

### Example

```sql
SELECT * FROM extract_path_segments('https://example.com/api/v2/users?page=1');
┌───────────────┬─────────┐
│ segment_index │ segment │
│     int32     │ varchar │
├───────────────┼─────────┤
│             1 │ api     │
│             2 │ v2      │
│             3 │ users   │
└───────────────┴─────────┘