### PR TITLE
Add `url_encode` / `url_decode` Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Table of Contents
     - [Validate URL](#validate-url)
     - [Validate Domain](#validate-domain)
     - [Extract Path Segments](#extract-path-segments)
+    - [URL Encode / Decode](#url-encode--decode)
     - [Get Extension Version](#get-extension-version)
   - [Build Requirements](#build-requirements)
   - [Debugging](#debugging)
@@ -832,6 +833,58 @@ D SELECT u.url,
 └───────────────────────────┴───────────────┴─────────┘
 ```
 
+### URL Encode / Decode
+
+The `url_encode` function percent-encodes a string per RFC 3986. Only unreserved characters (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`) are left as-is — everything else is encoded as `%XX` with uppercase hex digits.
+
+The `url_decode` function decodes percent-encoded strings back to their original form. It also decodes `+` as a space (for `application/x-www-form-urlencoded` compatibility). Invalid percent sequences are passed through literally.
+
+```sql
+D SELECT url_encode('hello world') AS encoded;
+┌───────────────┐
+│    encoded    │
+│    varchar    │
+├───────────────┤
+│ hello%20world │
+└───────────────┘
+
+D SELECT url_decode('hello%20world') AS decoded;
+┌─────────────┐
+│   decoded   │
+│   varchar   │
+├─────────────┤
+│ hello world │
+└─────────────┘
+
+D SELECT url_encode('https://www.google.com/search?client=firefox-b-d&q=url+encode') AS encoded;
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                                     encoded                                     │
+│                                     varchar                                     │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│ https%3A%2F%2Fwww.google.com%2Fsearch%3Fclient%3Dfirefox-b-d%26q%3Durl%2Bencode │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+D SELECT url_decode(url_encode('café 🦆')) AS roundtrip;
+┌───────────┐
+│ roundtrip │
+│  varchar  │
+├───────────┤
+│ café 🦆   │
+└───────────┘
+```
+
+`url_decode` also decodes `+` as space:
+
+```sql
+D SELECT url_decode('hello+world') AS decoded;
+┌─────────────┐
+│   decoded   │
+│   varchar   │
+├─────────────┤
+│ hello world │
+└─────────────┘
+```
+
 ### Get Extension Version
 
 You can use the `netquack_version` function to get the extension version.
@@ -874,7 +927,6 @@ Also, there will be stdout errors for background tasks like CURL.
 - [ ] Save Tranco data as Parquet
 - [ ] Implement GeoIP functionality
 - [ ] Return default value for `get_tranco_rank`
-- [ ] Implement `url_encode` / `url_decode` functions - Standalone percent-encoding and decoding
 - [ ] Implement `ip_in_range` function - Check if an IP falls within a given CIDR block
 - [ ] Support internationalized domain names (IDNs)
 - [ ] Implement `punycode_encode` / `punycode_decode` functions - Convert internationalized domain names to/from ASCII-compatible encoding

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -27,6 +27,7 @@
 * [Validate URL](functions/is-valid-url.md)
 * [Validate Domain](functions/is-valid-domain.md)
 * [Extract Path Segments](functions/extract-path-segments.md)
+* [URL Encode / Decode](functions/url-encode-functions.md)
 * [Tranco](functions/tranco/README.md)
   * [Get Tranco Rank](functions/tranco/get-tranco-rank.md)
   * [Download / Update Tranco](functions/tranco/download-update-tranco.md)

--- a/docs/functions/url-encode-functions.md
+++ b/docs/functions/url-encode-functions.md
@@ -1,0 +1,97 @@
+---
+layout:
+  title:
+    visible: true
+  description:
+    visible: false
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+---
+
+# URL Encode / Decode
+
+The `url_encode` function percent-encodes a string per RFC 3986. Only unreserved characters (`A-Z`, `a-z`, `0-9`, `-`, `_`, `.`, `~`) are left as-is — everything else is encoded as `%XX` with uppercase hex digits.
+
+The `url_decode` function decodes percent-encoded strings back to their original form. It also decodes `+` as a space (for `application/x-www-form-urlencoded` compatibility). Invalid percent sequences (e.g., `%ZZ`, trailing `%`) are passed through literally.
+
+## Encode
+
+```sql
+D SELECT url_encode('hello world') AS encoded;
+┌───────────────┐
+│    encoded    │
+│    varchar    │
+├───────────────┤
+│ hello%20world │
+└───────────────┘
+```
+
+```sql
+D SELECT url_encode('café') AS encoded;
+┌───────────┐
+│  encoded  │
+│  varchar  │
+├───────────┤
+│ caf%C3%A9 │
+└───────────┘
+```
+
+```sql
+D SELECT url_encode('key=value&lang=en') AS encoded;
+┌───────────────────────────┐
+│          encoded          │
+│          varchar          │
+├───────────────────────────┤
+│ key%3Dvalue%26lang%3Den   │
+└───────────────────────────┘
+```
+
+## Decode
+
+```sql
+D SELECT url_decode('hello%20world') AS decoded;
+┌─────────────┐
+│   decoded   │
+│   varchar   │
+├─────────────┤
+│ hello world │
+└─────────────┘
+```
+
+```sql
+D SELECT url_decode('hello+world') AS decoded;
+┌─────────────┐
+│   decoded   │
+│   varchar   │
+├─────────────┤
+│ hello world │
+└─────────────┘
+```
+
+```sql
+D SELECT url_decode('caf%C3%A9') AS decoded;
+┌─────────┐
+│ decoded │
+│ varchar │
+├─────────┤
+│ café    │
+└─────────┘
+```
+
+## Round-trip
+
+```sql
+D SELECT url_decode(url_encode('https://example.com/path?q=hello world')) AS roundtrip;
+┌──────────────────────────────────────────┐
+│                roundtrip                 │
+│                 varchar                  │
+├──────────────────────────────────────────┤
+│ https://example.com/path?q=hello world   │
+└──────────────────────────────────────────┘
+```
+
+Returns an empty string for empty input and `NULL` for `NULL` input.

--- a/src/functions/url_encode_functions.cpp
+++ b/src/functions/url_encode_functions.cpp
@@ -1,0 +1,146 @@
+// Copyright 2026 Arash Hatami
+
+#include "url_encode_functions.hpp"
+
+#include <array>
+#include <sstream>
+
+namespace duckdb {
+
+// RFC 3986 unreserved characters: A-Z a-z 0-9 - _ . ~
+// These are the ONLY characters that are NOT percent-encoded.
+static constexpr std::array<bool, 256> BuildUnreservedTable() {
+	std::array<bool, 256> table = {};
+	for (auto &v : table) {
+		v = false;
+	}
+	// A-Z
+	for (int c = 'A'; c <= 'Z'; c++) {
+		table[c] = true;
+	}
+	// a-z
+	for (int c = 'a'; c <= 'z'; c++) {
+		table[c] = true;
+	}
+	// 0-9
+	for (int c = '0'; c <= '9'; c++) {
+		table[c] = true;
+	}
+	// - _ . ~
+	table[static_cast<uint8_t>('-')] = true;
+	table[static_cast<uint8_t>('_')] = true;
+	table[static_cast<uint8_t>('.')] = true;
+	table[static_cast<uint8_t>('~')] = true;
+	return table;
+}
+
+static constexpr auto UNRESERVED_TABLE = BuildUnreservedTable();
+
+static const char HEX_DIGITS[] = "0123456789ABCDEF";
+
+// Returns -1 for invalid hex character
+static int HexVal(char c) {
+	if (c >= '0' && c <= '9') {
+		return c - '0';
+	}
+	if (c >= 'a' && c <= 'f') {
+		return c - 'a' + 10;
+	}
+	if (c >= 'A' && c <= 'F') {
+		return c - 'A' + 10;
+	}
+	return -1;
+}
+
+void UrlEncodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input_vector = args.data[0];
+	auto result_data = FlatVector::GetData<string_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < args.size(); i++) {
+		auto value = input_vector.GetValue(i);
+		if (value.IsNull()) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		auto input = value.ToString();
+		auto encoded = netquack::UrlEncode(input);
+		result_data[i] = StringVector::AddString(result, encoded);
+	}
+}
+
+void UrlDecodeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &input_vector = args.data[0];
+	auto result_data = FlatVector::GetData<string_t>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < args.size(); i++) {
+		auto value = input_vector.GetValue(i);
+		if (value.IsNull()) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		auto input = value.ToString();
+		auto decoded = netquack::UrlDecode(input);
+		result_data[i] = StringVector::AddString(result, decoded);
+	}
+}
+
+namespace netquack {
+
+std::string UrlEncode(const std::string &input) {
+	if (input.empty()) {
+		return "";
+	}
+
+	std::string result;
+	// Worst case: every byte becomes %XX (3x expansion)
+	result.reserve(input.size() * 3);
+
+	for (unsigned char c : input) {
+		if (UNRESERVED_TABLE[c]) {
+			result += static_cast<char>(c);
+		} else {
+			result += '%';
+			result += HEX_DIGITS[(c >> 4) & 0x0F];
+			result += HEX_DIGITS[c & 0x0F];
+		}
+	}
+
+	return result;
+}
+
+std::string UrlDecode(const std::string &input) {
+	if (input.empty()) {
+		return "";
+	}
+
+	std::string result;
+	result.reserve(input.size());
+
+	for (size_t i = 0; i < input.size(); i++) {
+		if (input[i] == '%' && i + 2 < input.size()) {
+			int hi = HexVal(input[i + 1]);
+			int lo = HexVal(input[i + 2]);
+			if (hi >= 0 && lo >= 0) {
+				result += static_cast<char>((hi << 4) | lo);
+				i += 2;
+				continue;
+			}
+			// Invalid hex digits — pass through the '%' literally
+			result += '%';
+		} else if (input[i] == '+') {
+			// '+' is commonly used as space in application/x-www-form-urlencoded
+			result += ' ';
+		} else {
+			result += input[i];
+		}
+	}
+
+	return result;
+}
+
+} // namespace netquack
+} // namespace duckdb

--- a/src/functions/url_encode_functions.hpp
+++ b/src/functions/url_encode_functions.hpp
@@ -1,0 +1,15 @@
+// Copyright 2026 Arash Hatami
+
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+void UrlEncodeFunction(DataChunk &args, ExpressionState &state, Vector &result);
+void UrlDecodeFunction(DataChunk &args, ExpressionState &state, Vector &result);
+
+namespace netquack {
+std::string UrlEncode(const std::string &input);
+std::string UrlDecode(const std::string &input);
+} // namespace netquack
+} // namespace duckdb

--- a/src/netquack_extension.cpp
+++ b/src/netquack_extension.cpp
@@ -14,6 +14,7 @@
 #include "functions/extract_host.hpp"
 #include "functions/extract_path.hpp"
 #include "functions/extract_path_segments.hpp"
+#include "functions/url_encode_functions.hpp"
 #include "functions/extract_port.hpp"
 #include "functions/extract_query.hpp"
 #include "functions/extract_schema.hpp"
@@ -144,6 +145,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                  nullptr, netquack::ExtractPathSegmentsFunc::InitLocal);
 	extract_path_segments_function.in_out_function = netquack::ExtractPathSegmentsFunc::Function;
 	loader.RegisterFunction(extract_path_segments_function);
+
+	auto url_encode_function =
+	    ScalarFunction("url_encode", {LogicalType::VARCHAR}, LogicalType::VARCHAR, UrlEncodeFunction);
+	loader.RegisterFunction(url_encode_function);
+
+	auto url_decode_function =
+	    ScalarFunction("url_decode", {LogicalType::VARCHAR}, LogicalType::VARCHAR, UrlDecodeFunction);
+	loader.RegisterFunction(url_decode_function);
 
 	auto version_function =
 	    TableFunction("netquack_version", {}, netquack::VersionFunc::Scan, netquack::VersionFunc::Bind,

--- a/test/sql/null_handling.test
+++ b/test/sql/null_handling.test
@@ -94,6 +94,18 @@ SELECT is_valid_domain(NULL);
 ----
 NULL
 
+# Test NULL handling for url_encode
+query I
+SELECT url_encode(NULL);
+----
+NULL
+
+# Test NULL handling for url_decode
+query I
+SELECT url_decode(NULL);
+----
+NULL
+
 # Test NULL values in a table
 statement ok
 CREATE TABLE test_nulls (url VARCHAR);

--- a/test/sql/url_encode_functions.test
+++ b/test/sql/url_encode_functions.test
@@ -1,0 +1,433 @@
+# name: test/sql/url_encode_functions.test
+# description: test netquack url_encode and url_decode
+# group: [sql]
+
+require netquack
+
+# === Basic url_encode ===
+
+query I
+SELECT url_encode('hello world');
+----
+hello%20world
+
+query I
+SELECT url_encode('foo bar baz');
+----
+foo%20bar%20baz
+
+query I
+SELECT url_encode('abc123');
+----
+abc123
+
+query I
+SELECT url_encode('a-b_c.d~e');
+----
+a-b_c.d~e
+
+# === Unreserved characters pass through ===
+
+query I
+SELECT url_encode('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~');
+----
+ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~
+
+# === Reserved characters are encoded ===
+
+query I
+SELECT url_encode(':/?#[]@!$&''()*+,;=');
+----
+%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D
+
+query I
+SELECT url_encode('key=value&key2=value2');
+----
+key%3Dvalue%26key2%3Dvalue2
+
+# === Spaces ===
+
+query I
+SELECT url_encode('hello world');
+----
+hello%20world
+
+query I
+SELECT url_encode(' ');
+----
+%20
+
+query I
+SELECT url_encode('  leading and trailing  ');
+----
+%20%20leading%20and%20trailing%20%20
+
+# === Special characters ===
+
+query I
+SELECT url_encode('100%');
+----
+100%25
+
+query I
+SELECT url_encode('price: $19.99');
+----
+price%3A%20%2419.99
+
+query I
+SELECT url_encode('<script>alert("xss")</script>');
+----
+%3Cscript%3Ealert%28%22xss%22%29%3C%2Fscript%3E
+
+query I
+SELECT url_encode('path/to/file');
+----
+path%2Fto%2Ffile
+
+# === URL components ===
+
+query I
+SELECT url_encode('https://example.com/path?q=hello world&lang=en');
+----
+https%3A%2F%2Fexample.com%2Fpath%3Fq%3Dhello%20world%26lang%3Den
+
+query I
+SELECT url_encode('user@example.com');
+----
+user%40example.com
+
+# === Unicode / UTF-8 ===
+
+query I
+SELECT url_encode('café');
+----
+caf%C3%A9
+
+query I
+SELECT url_encode('日本語');
+----
+%E6%97%A5%E6%9C%AC%E8%AA%9E
+
+query I
+SELECT url_encode('über');
+----
+%C3%BCber
+
+query I
+SELECT url_encode('emoji: 🦆');
+----
+emoji%3A%20%F0%9F%A6%86
+
+# === Empty string ===
+
+query I
+SELECT url_encode('');
+----
+(empty)
+
+# === NULL ===
+
+query I
+SELECT url_encode(NULL);
+----
+NULL
+
+# =========================================
+# === Basic url_decode ===
+# =========================================
+
+query I
+SELECT url_decode('hello%20world');
+----
+hello world
+
+query I
+SELECT url_decode('foo%20bar%20baz');
+----
+foo bar baz
+
+query I
+SELECT url_decode('abc123');
+----
+abc123
+
+# === Unreserved pass through ===
+
+query I
+SELECT url_decode('a-b_c.d~e');
+----
+a-b_c.d~e
+
+# === Decode reserved characters ===
+
+query I
+SELECT url_decode('%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D');
+----
+:/?#[]@!$&'()*+,;=
+
+query I
+SELECT url_decode('key%3Dvalue%26key2%3Dvalue2');
+----
+key=value&key2=value2
+
+# === Plus sign decoded as space ===
+
+query I
+SELECT url_decode('hello+world');
+----
+hello world
+
+query I
+SELECT url_decode('key+name=some+value');
+----
+key name=some value
+
+# === Mixed percent and plus ===
+
+query I
+SELECT url_decode('hello%20world+foo');
+----
+hello world foo
+
+# === Lowercase hex digits ===
+
+query I
+SELECT url_decode('hello%20world');
+----
+hello world
+
+query I
+SELECT url_decode('caf%c3%a9');
+----
+café
+
+# === Uppercase hex digits ===
+
+query I
+SELECT url_decode('caf%C3%A9');
+----
+café
+
+# === Mixed case hex ===
+
+query I
+SELECT url_decode('%c3%A9');
+----
+é
+
+# === Invalid percent sequences pass through ===
+
+query I
+SELECT url_decode('%ZZ');
+----
+%ZZ
+
+query I
+SELECT url_decode('%');
+----
+%
+
+query I
+SELECT url_decode('%2');
+----
+%2
+
+query I
+SELECT url_decode('100%');
+----
+100%
+
+query I
+SELECT url_decode('%%20');
+----
+% 
+
+# === UTF-8 round-trip ===
+
+query I
+SELECT url_decode('%E6%97%A5%E6%9C%AC%E8%AA%9E');
+----
+日本語
+
+query I
+SELECT url_decode('%C3%BCber');
+----
+über
+
+query I
+SELECT url_decode('%F0%9F%A6%86');
+----
+🦆
+
+# === Full URL decode ===
+
+query I
+SELECT url_decode('https%3A%2F%2Fexample.com%2Fpath%3Fq%3Dhello%20world%26lang%3Den');
+----
+https://example.com/path?q=hello world&lang=en
+
+# === Empty string ===
+
+query I
+SELECT url_decode('');
+----
+(empty)
+
+# === NULL ===
+
+query I
+SELECT url_decode(NULL);
+----
+NULL
+
+# =========================================
+# === Round-trip tests ===
+# =========================================
+
+query I
+SELECT url_decode(url_encode('hello world'));
+----
+hello world
+
+query I
+SELECT url_decode(url_encode('https://example.com/path?q=test&lang=en'));
+----
+https://example.com/path?q=test&lang=en
+
+query I
+SELECT url_decode(url_encode('café 日本語 🦆'));
+----
+café 日本語 🦆
+
+query I
+SELECT url_decode(url_encode('special: <>&"'''));
+----
+special: <>&"'
+
+query I
+SELECT url_decode(url_encode('100% done!'));
+----
+100% done!
+
+query I
+SELECT url_decode(url_encode(''));
+----
+(empty)
+
+# =========================================
+# === Table usage ===
+# =========================================
+
+statement ok
+CREATE OR REPLACE TABLE test_urls AS
+SELECT * FROM (VALUES
+    ('hello world'),
+    ('café'),
+    ('key=value&a=1'),
+    ('https://example.com'),
+    ('')
+) AS t(input);
+
+query II
+SELECT input, url_encode(input) FROM test_urls ORDER BY input;
+----
+(empty)	(empty)
+café	caf%C3%A9
+hello world	hello%20world
+https://example.com	https%3A%2F%2Fexample.com
+key=value&a=1	key%3Dvalue%26a%3D1
+
+query II
+SELECT input, url_decode(url_encode(input)) AS roundtrip FROM test_urls ORDER BY input;
+----
+(empty)	(empty)
+café	café
+hello world	hello world
+https://example.com	https://example.com
+key=value&a=1	key=value&a=1
+
+statement ok
+DROP TABLE test_urls;
+
+# === Encoded strings table ===
+
+statement ok
+CREATE OR REPLACE TABLE encoded_data AS
+SELECT * FROM (VALUES
+    ('hello%20world'),
+    ('caf%C3%A9'),
+    ('key%3Dvalue%26a%3D1'),
+    ('hello+world'),
+    ('%E6%97%A5%E6%9C%AC%E8%AA%9E')
+) AS t(encoded);
+
+query II
+SELECT encoded, url_decode(encoded) FROM encoded_data ORDER BY encoded;
+----
+%E6%97%A5%E6%9C%AC%E8%AA%9E	日本語
+caf%C3%A9	café
+hello%20world	hello world
+hello+world	hello world
+key%3Dvalue%26a%3D1	key=value&a=1
+
+statement ok
+DROP TABLE encoded_data;
+
+# === GROUP BY with url_encode ===
+
+statement ok
+CREATE OR REPLACE TABLE mixed_data AS
+SELECT * FROM (VALUES
+    ('hello world'),
+    ('hello world'),
+    ('café'),
+    ('café'),
+    ('café'),
+    ('test')
+) AS t(val);
+
+query II
+SELECT url_encode(val) AS encoded, count(*) AS cnt FROM mixed_data GROUP BY url_encode(val) ORDER BY encoded;
+----
+caf%C3%A9	3
+hello%20world	2
+test	1
+
+statement ok
+DROP TABLE mixed_data;
+
+# === Encode NUL byte via chr() ===
+
+query I
+SELECT url_encode(chr(0));
+----
+%00
+
+# === Encode all control characters (0-31) produce percent encoding ===
+
+query I
+SELECT url_encode(chr(1));
+----
+%01
+
+query I
+SELECT url_encode(chr(9));
+----
+%09
+
+query I
+SELECT url_encode(chr(10));
+----
+%0A
+
+query I
+SELECT url_encode(chr(13));
+----
+%0D
+
+# === Decode %00 produces NUL ===
+
+query I
+SELECT length(url_decode('%00'));
+----
+1


### PR DESCRIPTION
Standalone percent-encoding and decoding per RFC 3986.

### Key Design Decisions

- **RFC 3986 unreserved set**: Only `A-Za-z0-9-_.~` pass through unencoded — strictest correct behavior
- **`+` as space in decode**: Supports `application/x-www-form-urlencoded` format (common in web forms)
- **Invalid sequences preserved**: `%ZZ`, trailing `%`, `%2` pass through literally instead of erroring
- **Uppercase hex output**: `%C3%A9` not `%c3%a9` — canonical form per RFC 3986

### Example

```sql
SELECT url_encode('café 🦆') AS encoded;
-- caf%C3%A9%20%F0%9F%A6%86

SELECT url_decode('caf%C3%A9%20%F0%9F%A6%86') AS decoded;
-- café 🦆